### PR TITLE
Using lap times instead of laps

### DIFF
--- a/msg/ExtraInfo.msg
+++ b/msg/ExtraInfo.msg
@@ -2,4 +2,4 @@
 uint32 doo_counter
 
 # The number of finished laps driven by the vehicle
-uint32 laps 
+float64[] laps 

--- a/msg/ExtraInfo.msg
+++ b/msg/ExtraInfo.msg
@@ -2,4 +2,4 @@
 uint32 doo_counter
 
 # The number of finished laps driven by the vehicle
-float64[] laps 
+float32[] laps 


### PR DESCRIPTION
Changing the Extra info message to use lap times instead of number of laps