### PR TITLE
Fix for 22.04 cmake cut-offs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 project(fs_msgs)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
Tested on Humble Ubuntu 22.04 and Galactic Ubuntu 20.04 with Cmake 3.21.
Not sure why it needed 3.18 as a minimum, I was getting 'can't find python package include directories' with 3.5 which is odd, but others mileage may vary.